### PR TITLE
Fix Pipeline Documentation

### DIFF
--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -355,7 +355,8 @@ object ZPipeline extends ZPipelineCompanionVersionSpecific with ZPipelinePlatfor
     }
 
   /**
-   * Creates a pipeline that maps elements with the specified function.
+   * Creates a pipeline that maps chunks of elements with the specified
+   * function.
    */
   def mapChunks[In, Out](
     f: Chunk[In] => Chunk[Out]

--- a/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
+++ b/streams/shared/src/main/scala/zio/stream/ZPipeline.scala
@@ -355,6 +355,32 @@ object ZPipeline extends ZPipelineCompanionVersionSpecific with ZPipelinePlatfor
     }
 
   /**
+   * Creates a pipeline that maps elements with the specified function.
+   */
+  def mapChunks[In, Out](
+    f: Chunk[In] => Chunk[Out]
+  ): ZPipeline.WithOut[
+    Nothing,
+    Any,
+    Nothing,
+    Any,
+    Nothing,
+    In,
+    ({ type OutEnv[Env] = Env })#OutEnv,
+    ({ type OutErr[Err] = Err })#OutErr,
+    ({ type OutElem[Elem] = Out })#OutElem
+  ] =
+    new ZPipeline[Nothing, Any, Nothing, Any, Nothing, In] {
+      type OutEnv[Env]   = Env
+      type OutErr[Err]   = Err
+      type OutElem[Elem] = Out
+      def apply[Env, Err, Elem <: In](stream: ZStream[Env, Err, Elem])(implicit
+        trace: ZTraceElement
+      ): ZStream[Env, Err, Out] =
+        stream.mapChunks(f)
+    }
+
+  /**
    * Emits the provided chunk before emitting any other value.
    */
   def prepend[In](values: Chunk[In]): ZPipeline.WithOut[


### PR DESCRIPTION
Updated documentation for pipeline examples. I removed the branching example for now. John and I had some discussion that a pipeline should always use its input and so we shouldn't have a `fail` constructor, though I see how that can be useful with branching.